### PR TITLE
FIX CLI command for CGGTTS

### DIFF
--- a/src/cli/positioning.rs
+++ b/src/cli/positioning.rs
@@ -49,7 +49,7 @@ The default profile is \"pedestrian\" (very low velocity), which is not suited f
 The default profile is Oscillator/OCXO."))
 .arg(
     Arg::new("atomic")
-        .long("quartz")
+        .long("atomic")
         .action(ArgAction::SetTrue)
         .help("Define atomic (rover clock) profile (high quality, at the scale of a GNSS constellation).
 The default profile is Oscillator/OCXO."))

--- a/src/positioning/cggtts/post_process.rs
+++ b/src/positioning/cggtts/post_process.rs
@@ -35,18 +35,14 @@ pub fn post_process(
     //     }
     // })
 
-    // agency customization
-    if let Some(custom) = matches.get_one::<String>("agency") {
-        header = header.with_station(custom);
+    // TODO: agency customization
+    let stem = Context::context_stem(&ctx.data);
+    let value = if let Some(index) = stem.find('_') {
+        stem[..index].to_string()
     } else {
-        let stem = Context::context_stem(&ctx.data);
-        let value = if let Some(index) = stem.find('_') {
-            stem[..index].to_string()
-        } else {
-            "LAB".to_string()
-        };
-        header = header.with_station(&value);
+        "LAB".to_string()
     };
+    header = header.with_station(&value);
 
     // TODO
     // header = header.with_receiver_hardware(rx);


### PR DESCRIPTION
The `main` branch can't be built, so I used the `gnss_rk_update` branch.

Running `rinex-cli` in debug mode will result in a parameter error, for example:
```
Command ppp: Long option names must be unique for each argument, but '--quartz' is in use by both 'quartz' and 'atomic'
```
I fixed the `atomic` parameter.
The `agency` parameter is not added in cggtts, so I removed it.